### PR TITLE
add Div support

### DIFF
--- a/src/pandoc.mli
+++ b/src/pandoc.mli
@@ -43,6 +43,7 @@ and block =
   | Para of inline list
   | Plain of inline list
   | RawBlock of format * string
+  | Div of attr * block list
   | UnhandledBlock of Yojson.Basic.t
 
 (** JSON representation of a pandoc file. *)


### PR DESCRIPTION
This block type allows us to write filters for handling `<div>`
elements, such as

```
::: {data-type=note}
Content
:::
```

We're using this in Real World OCaml v2 -- thanks for the great library @smimram!