### PR TITLE
include: close file descriptor after reading

### DIFF
--- a/examples/include.ml
+++ b/examples/include.ml
@@ -116,7 +116,7 @@ let () =
               done;
               ""
             with
-            | End_of_file | Exit -> !ans
+            | End_of_file | Exit -> close_in ic; !ans
           with
           | Sys_error _ as err ->
             error 1 "System error: %s." (Printexc.to_string err);


### PR DESCRIPTION
The second `open_in` in the include filter (used when `from`/`to` parameters
are present) is never explicitly closed when `End_of_file` or `Exit` is raised.
The file descriptor leaks on every such include.

In documents with many includes (e.g. ~500), this exhausts the process file
descriptor limit and causes a `Sys_error "Too many open files"` fatal error.

Fix: call `close_in ic` before returning the accumulated string.